### PR TITLE
Add basic WinForms UI and share LotoFetcher

### DIFF
--- a/Atarime.Core/LotoFetcher.cs
+++ b/Atarime.Core/LotoFetcher.cs
@@ -3,11 +3,10 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Atarime.Core;
 
-namespace Atarime.CLI;
+namespace Atarime.Core;
 
-internal static class LotoFetcher
+public static class LotoFetcher
 {
     private static readonly HttpClient _http = new();
 

--- a/Atarime.WinForms/Atarime.WinForms.csproj
+++ b/Atarime.WinForms/Atarime.WinForms.csproj
@@ -7,4 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Atarime.Core\Atarime.Core.csproj" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Add WinForms main form with buttons to fetch and show latest lotto results
- Move LotoFetcher into Core for reuse and reference from WinForms
- Wire up project references and CSV persistence

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a140e8f9a48332a16c74a2ccaaf288