### PR TITLE
Show progress when fetching lottery results

### DIFF
--- a/Atarime.CLI/Program.cs
+++ b/Atarime.CLI/Program.cs
@@ -9,22 +9,56 @@ internal class Program
     static async Task Main(string[] args)
     {
         var mode = args.Length > 0 ? args[0].ToLowerInvariant() : "loto6";
+        var all = args.Length > 1 && args[1].ToLowerInvariant() == "all";
+
         if (mode == "loto7")
         {
-            var result = await LotoFetcher.FetchLoto7Async();
-            if (result != null)
+            if (all)
             {
-                CsvStorage.AppendLoto7("loto7result.csv", result);
-                Console.WriteLine("Saved LOTO7 result.");
+                Console.WriteLine("Fetching all LOTO7 results...");
+                var results = await LotoFetcher.FetchAllLoto7Async(Console.WriteLine);
+                CsvStorage.WriteLoto7("loto7result.csv", results);
+                Console.WriteLine($"Saved {results.Count} LOTO7 results.");
+            }
+            else
+            {
+                Console.WriteLine("Fetching latest LOTO7 result...");
+                var result = await LotoFetcher.FetchLoto7Async(Console.WriteLine);
+                if (result != null)
+                {
+                    Console.WriteLine($"No.{result.No} {result.Date:yyyyMMdd}: {string.Join(",", result.Numbers)} +[{string.Join(",", result.Bonus)}]");
+                    CsvStorage.AppendLoto7("loto7result.csv", result);
+                    Console.WriteLine("Saved LOTO7 result.");
+                }
+                else
+                {
+                    Console.WriteLine("Failed to fetch LOTO7 result.");
+                }
             }
         }
         else
         {
-            var result = await LotoFetcher.FetchLoto6Async();
-            if (result != null)
+            if (all)
             {
-                CsvStorage.AppendLoto6("loto6result.csv", result);
-                Console.WriteLine("Saved LOTO6 result.");
+                Console.WriteLine("Fetching all LOTO6 results...");
+                var results = await LotoFetcher.FetchAllLoto6Async(Console.WriteLine);
+                CsvStorage.WriteLoto6("loto6result.csv", results);
+                Console.WriteLine($"Saved {results.Count} LOTO6 results.");
+            }
+            else
+            {
+                Console.WriteLine("Fetching latest LOTO6 result...");
+                var result = await LotoFetcher.FetchLoto6Async(Console.WriteLine);
+                if (result != null)
+                {
+                    Console.WriteLine($"No.{result.No} {result.Date:yyyyMMdd}: {string.Join(",", result.Numbers)} +[{result.Bonus}]");
+                    CsvStorage.AppendLoto6("loto6result.csv", result);
+                    Console.WriteLine("Saved LOTO6 result.");
+                }
+                else
+                {
+                    Console.WriteLine("Failed to fetch LOTO6 result.");
+                }
             }
         }
     }

--- a/Atarime.Core/CsvStorage.cs
+++ b/Atarime.Core/CsvStorage.cs
@@ -8,12 +8,31 @@ namespace Atarime.Core;
 
 public static class CsvStorage
 {
+    private static readonly string[] Loto6Header =
+        { "no", "date", "honsuji1", "honsuji2", "honsuji3", "honsuji4", "honsuji5", "honsuji6", "bonus_suji1" };
+
+    private static readonly string[] Loto7Header =
+        { "no", "date", "honsuji1", "honsuji2", "honsuji3", "honsuji4", "honsuji5", "honsuji6", "honsuji7", "bonus_suji1", "bonus_suji2" };
+
     public static void AppendLoto6(string path, Loto6Result result)
     {
+        EnsureHeader(path, Loto6Header);
         var line = string.Join(",",
+            $"第{result.No}回",
             result.Date.ToString("yyyyMMdd"),
             string.Join(",", result.Numbers.Select(n => n.ToString("00"))),
             result.Bonus.ToString("00"));
+        File.AppendAllText(path, line + Environment.NewLine);
+    }
+
+    public static void AppendLoto7(string path, Loto7Result result)
+    {
+        EnsureHeader(path, Loto7Header);
+        var line = string.Join(",",
+            $"第{result.No}回",
+            result.Date.ToString("yyyyMMdd"),
+            string.Join(",", result.Numbers.Select(n => n.ToString("00"))),
+            string.Join(",", result.Bonus.Select(n => n.ToString("00"))));
         File.AppendAllText(path, line + Environment.NewLine);
     }
 
@@ -21,40 +40,69 @@ public static class CsvStorage
     {
         var list = new List<Loto6Result>();
         if (!File.Exists(path)) return list;
-        foreach (var line in File.ReadLines(path))
+        foreach (var line in File.ReadLines(path).Skip(1))
         {
             var parts = line.Split(',');
-            if (parts.Length < 8) continue;
-            var date = DateTime.ParseExact(parts[0], "yyyyMMdd", CultureInfo.InvariantCulture);
-            var numbers = parts.Skip(1).Take(6).Select(int.Parse).ToArray();
-            var bonus = int.Parse(parts[7]);
-            list.Add(new Loto6Result(date, numbers, bonus));
+            if (parts.Length < 9) continue;
+            var no = ParseNo(parts[0]);
+            var date = DateTime.ParseExact(parts[1], "yyyyMMdd", CultureInfo.InvariantCulture);
+            var numbers = parts.Skip(2).Take(6).Select(int.Parse).ToArray();
+            var bonus = int.Parse(parts[8]);
+            list.Add(new Loto6Result(no, date, numbers, bonus));
         }
         return list;
-    }
-
-    public static void AppendLoto7(string path, Loto7Result result)
-    {
-        var line = string.Join(",",
-            result.Date.ToString("yyyyMMdd"),
-            string.Join(",", result.Numbers.Select(n => n.ToString("00"))),
-            string.Join(",", result.Bonus.Select(n => n.ToString("00"))));
-        File.AppendAllText(path, line + Environment.NewLine);
     }
 
     public static List<Loto7Result> ReadLoto7(string path)
     {
         var list = new List<Loto7Result>();
         if (!File.Exists(path)) return list;
-        foreach (var line in File.ReadLines(path))
+        foreach (var line in File.ReadLines(path).Skip(1))
         {
             var parts = line.Split(',');
-            if (parts.Length < 10) continue;
-            var date = DateTime.ParseExact(parts[0], "yyyyMMdd", CultureInfo.InvariantCulture);
-            var numbers = parts.Skip(1).Take(7).Select(int.Parse).ToArray();
-            var bonus = parts.Skip(8).Take(2).Select(int.Parse).ToArray();
-            list.Add(new Loto7Result(date, numbers, bonus));
+            if (parts.Length < 11) continue;
+            var no = ParseNo(parts[0]);
+            var date = DateTime.ParseExact(parts[1], "yyyyMMdd", CultureInfo.InvariantCulture);
+            var numbers = parts.Skip(2).Take(7).Select(int.Parse).ToArray();
+            var bonus = parts.Skip(9).Take(2).Select(int.Parse).ToArray();
+            list.Add(new Loto7Result(no, date, numbers, bonus));
         }
         return list;
+    }
+
+    public static void WriteLoto6(string path, IEnumerable<Loto6Result> results)
+    {
+        var lines = new List<string> { string.Join(",", Loto6Header) };
+        lines.AddRange(results.Select(r => string.Join(",",
+            $"第{r.No}回",
+            r.Date.ToString("yyyyMMdd"),
+            string.Join(",", r.Numbers.Select(n => n.ToString("00"))),
+            r.Bonus.ToString("00"))));
+        File.WriteAllLines(path, lines);
+    }
+
+    public static void WriteLoto7(string path, IEnumerable<Loto7Result> results)
+    {
+        var lines = new List<string> { string.Join(",", Loto7Header) };
+        lines.AddRange(results.Select(r => string.Join(",",
+            $"第{r.No}回",
+            r.Date.ToString("yyyyMMdd"),
+            string.Join(",", r.Numbers.Select(n => n.ToString("00"))),
+            string.Join(",", r.Bonus.Select(n => n.ToString("00"))))));
+        File.WriteAllLines(path, lines);
+    }
+
+    private static void EnsureHeader(string path, string[] header)
+    {
+        if (!File.Exists(path))
+        {
+            File.WriteAllText(path, string.Join(",", header) + Environment.NewLine);
+        }
+    }
+
+    private static int ParseNo(string s)
+    {
+        var m = System.Text.RegularExpressions.Regex.Match(s, @"第(\d+)回");
+        return m.Success ? int.Parse(m.Groups[1].Value) : int.Parse(s);
     }
 }

--- a/Atarime.Core/LotoFetcher.cs
+++ b/Atarime.Core/LotoFetcher.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Linq;
 using System.Net.Http;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
+using System.Globalization;
+using System.Text;
 
 namespace Atarime.Core;
 
@@ -10,49 +12,200 @@ public static class LotoFetcher
 {
     private static readonly HttpClient _http = new();
 
-    public static async Task<Loto6Result?> FetchLoto6Async()
+    static LotoFetcher()
+    {
+        _http.DefaultRequestHeaders.UserAgent.ParseAdd(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/139.0.0.0 Safari/537.36");
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    public static async Task<Loto6Result?> FetchLoto6Async(Action<string>? log = null)
     {
         try
         {
-            var html = await _http.GetStringAsync("https://www.mizuhobank.co.jp/takarakuji/check/loto/loto6/index.html");
-            var numbers = Regex.Matches(html, @"<td class=""alnCenter"">(\d{1,2})</td>")
-                               .Select(m => int.Parse(m.Groups[1].Value))
-                               .ToList();
-            if (numbers.Count >= 7)
-            {
-                var date = DateTime.Today;
-                var main = numbers.Take(6).ToArray();
-                var bonus = numbers[6];
-                return new Loto6Result(date, main, bonus);
-            }
+            var nameUrl = "https://www.mizuhobank.co.jp/takarakuji/apl/txt/loto6/name.txt";
+            log?.Invoke($"GET {nameUrl}");
+            var nameResp = await _http.GetAsync(nameUrl);
+            log?.Invoke($"Status {(int)nameResp.StatusCode} {nameResp.ReasonPhrase}");
+            var nameTxt = await nameResp.Content.ReadAsStringAsync();
+            log?.Invoke(nameTxt.Length > 200 ? nameTxt.Substring(0,200) + "..." : nameTxt);
+            nameResp.EnsureSuccessStatusCode();
+
+            var fileMatch = Regex.Match(nameTxt, @"A\d+\.CSV");
+            if (!fileMatch.Success)
+                throw new Exception("CSV name not found");
+
+            return await FetchLoto6ByFileAsync(fileMatch.Value, log);
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Fetch LOTO6 failed: {ex.Message}");
+            log?.Invoke($"Fetch LOTO6 failed: {ex.Message}");
+            if (log == null)
+                Console.Error.WriteLine($"Fetch LOTO6 failed: {ex.Message}");
+        }
+
+        return null;
+    }
+
+    private static async Task<Loto6Result?> FetchLoto6ByFileAsync(string file, Action<string>? log)
+    {
+        var csvUrl = $"https://www.mizuhobank.co.jp/retail/takarakuji/loto/loto6/csv/{file}";
+        log?.Invoke($"GET {csvUrl}");
+        var csvResp = await _http.GetAsync(csvUrl);
+        log?.Invoke($"Status {(int)csvResp.StatusCode} {csvResp.ReasonPhrase}");
+        csvResp.EnsureSuccessStatusCode();
+        var bytes = await csvResp.Content.ReadAsByteArrayAsync();
+        var csv = Encoding.GetEncoding("shift_jis").GetString(bytes);
+        log?.Invoke(csv.Length > 200 ? csv.Substring(0,200) + "..." : csv);
+
+        var lines = csv.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length < 4)
+            throw new Exception("CSV format unexpected");
+
+        var header = lines[1].Split(',');
+        var nums = lines[3].Split(',');
+
+        var noMatch = Regex.Match(header[0], @"第(\d+)回");
+        var no = noMatch.Success ? int.Parse(noMatch.Groups[1].Value) : 0;
+        var date = ParseJapaneseDate(header[2]);
+        var numbers = nums.Skip(1).Take(6).Select(s => int.Parse(s)).ToArray();
+        var bonus = int.Parse(nums[^1]);
+
+        return new Loto6Result(no, date, numbers, bonus);
+    }
+
+    private static DateTime ParseJapaneseDate(string s)
+    {
+        var m = Regex.Match(s, @"令和(\d+)年(\d+)月(\d+)日");
+        if (m.Success)
+        {
+            int year = int.Parse(m.Groups[1].Value) + 2018;
+            int month = int.Parse(m.Groups[2].Value);
+            int day = int.Parse(m.Groups[3].Value);
+            return new DateTime(year, month, day);
+        }
+        return DateTime.Parse(s, CultureInfo.InvariantCulture);
+    }
+
+    public static async Task<Loto7Result?> FetchLoto7Async(Action<string>? log = null)
+    {
+        try
+        {
+            var nameUrl = "https://www.mizuhobank.co.jp/takarakuji/apl/txt/loto7/name.txt";
+            log?.Invoke($"GET {nameUrl}");
+            var nameResp = await _http.GetAsync(nameUrl);
+            log?.Invoke($"Status {(int)nameResp.StatusCode} {nameResp.ReasonPhrase}");
+            var nameTxt = await nameResp.Content.ReadAsStringAsync();
+            log?.Invoke(nameTxt.Length > 200 ? nameTxt.Substring(0,200) + "..." : nameTxt);
+            nameResp.EnsureSuccessStatusCode();
+
+            var fileMatch = Regex.Match(nameTxt, @"A\d+\.CSV");
+            if (!fileMatch.Success)
+                throw new Exception("CSV name not found");
+
+            return await FetchLoto7ByFileAsync(fileMatch.Value, log);
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"Fetch LOTO7 failed: {ex.Message}");
+            if (log == null)
+                Console.Error.WriteLine($"Fetch LOTO7 failed: {ex.Message}");
         }
         return null;
     }
 
-    public static async Task<Loto7Result?> FetchLoto7Async()
+    private static async Task<Loto7Result?> FetchLoto7ByFileAsync(string file, Action<string>? log)
     {
+        var csvUrl = $"https://www.mizuhobank.co.jp/retail/takarakuji/loto/loto7/csv/{file}";
+        log?.Invoke($"GET {csvUrl}");
+        var csvResp = await _http.GetAsync(csvUrl);
+        log?.Invoke($"Status {(int)csvResp.StatusCode} {csvResp.ReasonPhrase}");
+        csvResp.EnsureSuccessStatusCode();
+        var bytes = await csvResp.Content.ReadAsByteArrayAsync();
+        var csv = Encoding.GetEncoding("shift_jis").GetString(bytes);
+        log?.Invoke(csv.Length > 200 ? csv.Substring(0,200) + "..." : csv);
+
+        var lines = csv.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+        if (lines.Length < 4)
+            throw new Exception("CSV format unexpected");
+
+        var header = lines[1].Split(',');
+        var nums = lines[3].Split(',');
+
+        var noMatch = Regex.Match(header[0], @"第(\d+)回");
+        var no = noMatch.Success ? int.Parse(noMatch.Groups[1].Value) : 0;
+        var date = ParseJapaneseDate(header[2]);
+        var numbers = nums.Skip(1).Take(7).Select(int.Parse).ToArray();
+        var bonus = nums.Skip(9).Take(2).Select(int.Parse).ToArray();
+
+        return new Loto7Result(no, date, numbers, bonus);
+    }
+
+    public static async Task<List<Loto6Result>> FetchAllLoto6Async(Action<string>? log = null)
+    {
+        var results = new List<Loto6Result>();
         try
         {
-            var html = await _http.GetStringAsync("https://www.mizuhobank.co.jp/takarakuji/check/loto/loto7/index.html");
-            var numbers = Regex.Matches(html, @"<td class=""alnCenter"">(\d{1,2})</td>")
-                               .Select(m => int.Parse(m.Groups[1].Value))
-                               .ToList();
-            if (numbers.Count >= 9)
+            var nameUrl = "https://www.mizuhobank.co.jp/takarakuji/apl/txt/loto6/name.txt";
+            log?.Invoke($"GET {nameUrl}");
+            var nameTxt = await _http.GetStringAsync(nameUrl);
+            log?.Invoke(nameTxt.Length > 200 ? nameTxt.Substring(0,200) + "..." : nameTxt);
+            var fileMatch = Regex.Match(nameTxt, @"A(\d{3})(\d{4})\.CSV");
+            if (!fileMatch.Success) throw new Exception("CSV name not found");
+            var prefix = fileMatch.Groups[1].Value;
+            int latest = int.Parse(fileMatch.Groups[2].Value);
+            for (int i = 1; i <= latest; i++)
             {
-                var date = DateTime.Today;
-                var main = numbers.Take(7).ToArray();
-                var bonus = numbers.Skip(7).Take(2).ToArray();
-                return new Loto7Result(date, main, bonus);
+                var file = $"A{prefix}{i:0000}.CSV";
+                try
+                {
+                    var r = await FetchLoto6ByFileAsync(file, log);
+                    if (r != null) results.Add(r);
+                }
+                catch (Exception ex)
+                {
+                    log?.Invoke($"Skip {file}: {ex.Message}");
+                }
             }
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Fetch LOTO7 failed: {ex.Message}");
+            log?.Invoke($"FetchAll LOTO6 failed: {ex.Message}");
         }
-        return null;
+        return results;
+    }
+
+    public static async Task<List<Loto7Result>> FetchAllLoto7Async(Action<string>? log = null)
+    {
+        var results = new List<Loto7Result>();
+        try
+        {
+            var nameUrl = "https://www.mizuhobank.co.jp/takarakuji/apl/txt/loto7/name.txt";
+            log?.Invoke($"GET {nameUrl}");
+            var nameTxt = await _http.GetStringAsync(nameUrl);
+            log?.Invoke(nameTxt.Length > 200 ? nameTxt.Substring(0,200) + "..." : nameTxt);
+            var fileMatch = Regex.Match(nameTxt, @"A(\d{3})(\d{4})\.CSV");
+            if (!fileMatch.Success) throw new Exception("CSV name not found");
+            var prefix = fileMatch.Groups[1].Value;
+            int latest = int.Parse(fileMatch.Groups[2].Value);
+            for (int i = 1; i <= latest; i++)
+            {
+                var file = $"A{prefix}{i:0000}.CSV";
+                try
+                {
+                    var r = await FetchLoto7ByFileAsync(file, log);
+                    if (r != null) results.Add(r);
+                }
+                catch (Exception ex)
+                {
+                    log?.Invoke($"Skip {file}: {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            log?.Invoke($"FetchAll LOTO7 failed: {ex.Message}");
+        }
+        return results;
     }
 }

--- a/Atarime.Core/LotoResults.cs
+++ b/Atarime.Core/LotoResults.cs
@@ -2,6 +2,6 @@ using System;
 
 namespace Atarime.Core;
 
-public record Loto6Result(DateTime Date, int[] Numbers, int Bonus);
+public record Loto6Result(int No, DateTime Date, int[] Numbers, int Bonus);
 
-public record Loto7Result(DateTime Date, int[] Numbers, int[] Bonus);
+public record Loto7Result(int No, DateTime Date, int[] Numbers, int[] Bonus);

--- a/Atarime.WinForms/MainForm.cs
+++ b/Atarime.WinForms/MainForm.cs
@@ -40,18 +40,38 @@ public class MainForm : Form
 
     private async Task FetchLatestAsync()
     {
-        var loto6 = await LotoFetcher.FetchLoto6Async();
-        if (loto6 != null)
+        void Log(string message)
         {
-            CsvStorage.AppendLoto6("loto6result.csv", loto6);
-            _output.AppendText($"LOTO6 {loto6.Date:yyyyMMdd}: {string.Join(",", loto6.Numbers)} +[{loto6.Bonus}]{Environment.NewLine}");
+            if (_output.InvokeRequired)
+                _output.Invoke(new Action(() => _output.AppendText(message + Environment.NewLine)));
+            else
+                _output.AppendText(message + Environment.NewLine);
         }
 
-        var loto7 = await LotoFetcher.FetchLoto7Async();
+        _output.AppendText("Fetching latest LOTO6..." + Environment.NewLine);
+        var loto6 = await LotoFetcher.FetchLoto6Async(Log);
+        if (loto6 != null)
+        {
+            _output.AppendText($"No.{loto6.No} {loto6.Date:yyyyMMdd}: {string.Join(",", loto6.Numbers)} +[{loto6.Bonus}]" + Environment.NewLine);
+            CsvStorage.AppendLoto6("loto6result.csv", loto6);
+            _output.AppendText("Saved LOTO6 result." + Environment.NewLine);
+        }
+        else
+        {
+            _output.AppendText("Failed to fetch LOTO6." + Environment.NewLine);
+        }
+
+        _output.AppendText("Fetching latest LOTO7..." + Environment.NewLine);
+        var loto7 = await LotoFetcher.FetchLoto7Async(Log);
         if (loto7 != null)
         {
+            _output.AppendText($"No.{loto7.No} {loto7.Date:yyyyMMdd}: {string.Join(",", loto7.Numbers)} +[{string.Join(",", loto7.Bonus)}]" + Environment.NewLine);
             CsvStorage.AppendLoto7("loto7result.csv", loto7);
-            _output.AppendText($"LOTO7 {loto7.Date:yyyyMMdd}: {string.Join(",", loto7.Numbers)} +[{string.Join(",", loto7.Bonus)}]{Environment.NewLine}");
+            _output.AppendText("Saved LOTO7 result." + Environment.NewLine);
+        }
+        else
+        {
+            _output.AppendText("Failed to fetch LOTO7." + Environment.NewLine);
         }
     }
 
@@ -59,22 +79,14 @@ public class MainForm : Form
     {
         var last6 = CsvStorage.ReadLoto6("loto6result.csv").LastOrDefault();
         if (last6 != null)
-        {
-            _output.AppendText($"Latest LOTO6: {last6.Date:yyyyMMdd} {string.Join(",", last6.Numbers)} +[{last6.Bonus}]{Environment.NewLine}");
-        }
+            _output.AppendText($"Latest LOTO6: No.{last6.No} {last6.Date:yyyyMMdd} {string.Join(",", last6.Numbers)} +[{last6.Bonus}]{Environment.NewLine}");
         else
-        {
             _output.AppendText("Latest LOTO6: no data\n");
-        }
 
         var last7 = CsvStorage.ReadLoto7("loto7result.csv").LastOrDefault();
         if (last7 != null)
-        {
-            _output.AppendText($"Latest LOTO7: {last7.Date:yyyyMMdd} {string.Join(",", last7.Numbers)} +[{string.Join(",", last7.Bonus)}]{Environment.NewLine}");
-        }
+            _output.AppendText($"Latest LOTO7: No.{last7.No} {last7.Date:yyyyMMdd} {string.Join(",", last7.Numbers)} +[{string.Join(",", last7.Bonus)}]{Environment.NewLine}");
         else
-        {
             _output.AppendText("Latest LOTO7: no data\n");
-        }
     }
 }

--- a/loto6result.csv
+++ b/loto6result.csv
@@ -1,2 +1,3 @@
-date,honsuji1,honsuji2,honsuji3,honsuji4,honsuji5,honsuji6,bonus_suji1
-20250815,12,18,26,28,41,43,35
+no,date,honsuji1,honsuji2,honsuji3,honsuji4,honsuji5,honsuji6,bonus_suji1
+第2025回,20250814,12,18,26,28,41,43,35
+第2025回,20250814,12,18,26,28,41,43,35

--- a/loto7result.csv
+++ b/loto7result.csv
@@ -1,2 +1,3 @@
-date,honsuji1,honsuji2,honsuji3,honsuji4,honsuji5,honsuji6,honsuji7,bonus_suji1,bonus_suji2
-20250815,05,09,12,15,30,31,34,13,29
+no,date,honsuji1,honsuji2,honsuji3,honsuji4,honsuji5,honsuji6,honsuji7,bonus_suji1,bonus_suji2
+第639回,20250815,05,09,12,15,30,31,34,13,29
+第639回,20250815,05,09,12,15,30,31,34,13,29


### PR DESCRIPTION
## Summary
- log and parse latest LOTO6/7 results from CSV including draw numbers
- add CSV helpers with draw "No" column and ability to write entire histories
- extend CLI & WinForms to display draw numbers and optionally fetch full history

## Testing
- `dotnet build`
- `dotnet run --project Atarime.CLI`
- `dotnet run --project Atarime.CLI loto7`
- `dotnet run --project Atarime.CLI loto6 all` *(fails early with 404 for old draws)*


------
https://chatgpt.com/codex/tasks/task_e_68a147dbee8c83328e24f658cd414a0c