### PR TITLE
fix: remove stray else statements

### DIFF
--- a/Atarime.CLI/Program.cs
+++ b/Atarime.CLI/Program.cs
@@ -36,10 +36,6 @@ internal class Program
                 }
 
             }
-            else
-            {
-                Console.WriteLine("Failed to fetch LOTO7 result.");
-            }
         }
         else
         {
@@ -65,10 +61,6 @@ internal class Program
                     Console.WriteLine("Failed to fetch LOTO6 result.");
                 }
 
-            }
-            else
-            {
-                Console.WriteLine("Failed to fetch LOTO6 result.");
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove stray else blocks in CLI program to resolve syntax errors

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68a1dcaa41ac83329935814faa483534