### PR TITLE
Add recent loto statistics printer

### DIFF
--- a/Atarime.Statistics/StatisticsCalculator.cs
+++ b/Atarime.Statistics/StatisticsCalculator.cs
@@ -24,4 +24,26 @@ public static class StatisticsCalculator
 
     public static Dictionary<int, int> CalculateNumberFrequencies(IEnumerable<Loto7Result> results)
         => CountNumbers(results.Select(r => r.Numbers));
+
+    private static IEnumerable<KeyValuePair<int, int>> TopNumbers(Dictionary<int, int> frequencies, int topCount)
+        => frequencies
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key)
+            .Take(topCount);
+
+    public static IEnumerable<KeyValuePair<int, int>> GetMostFrequentNumbers(
+        IEnumerable<Loto6Result> results, int windowSize, int topCount)
+    {
+        var subset = results.TakeLast(windowSize);
+        var freq = CalculateNumberFrequencies(subset);
+        return TopNumbers(freq, topCount);
+    }
+
+    public static IEnumerable<KeyValuePair<int, int>> GetMostFrequentNumbers(
+        IEnumerable<Loto7Result> results, int windowSize, int topCount)
+    {
+        var subset = results.TakeLast(windowSize);
+        var freq = CalculateNumberFrequencies(subset);
+        return TopNumbers(freq, topCount);
+    }
 }

--- a/Atarime.Statistics/StatisticsPrinter.cs
+++ b/Atarime.Statistics/StatisticsPrinter.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Linq;
+using Atarime.Core;
+
+namespace Atarime.Statistics;
+
+/// <summary>
+/// Helper class to print frequent numbers for recent LOTO6 and LOTO7 draws.
+/// </summary>
+public static class StatisticsPrinter
+{
+    private static readonly int[] Windows = { 100, 50, 25, 10, 5 };
+
+    public static void PrintLoto6()
+    {
+        var results = CsvStorage.ReadLoto6(ResultPaths.Loto6);
+        foreach (var w in Windows)
+        {
+            var top = StatisticsCalculator
+                .GetMostFrequentNumbers(results, w, 6)
+                .Select(kv => $"{kv.Key}({kv.Value})");
+            Console.WriteLine($"LOTO6 last {Math.Min(w, results.Count)}: {string.Join(", ", top)}");
+        }
+    }
+
+    public static void PrintLoto7()
+    {
+        var results = CsvStorage.ReadLoto7(ResultPaths.Loto7);
+        foreach (var w in Windows)
+        {
+            var top = StatisticsCalculator
+                .GetMostFrequentNumbers(results, w, 7)
+                .Select(kv => $"{kv.Key}({kv.Value})");
+            Console.WriteLine($"LOTO7 last {Math.Min(w, results.Count)}: {string.Join(", ", top)}");
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helpers to compute most frequent numbers over recent draws
- add printer to show top LOTO6/7 numbers for the last 100, 50, 25, 10 and 5 rounds

## Testing
- `dotnet test` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*
- `dotnet build Atarime.Statistics/Atarime.Statistics.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a1f3a2a8748332a82f675a036668c1